### PR TITLE
Fix npm package for ios, missing headers / framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2020-01-21
+### Fixed
+- Missing SpotifyiOS headers / Framework [#25](https://github.com/cjam/react-native-spotify-remote/issues/20)
+
 ## [0.1.0] - 2020-01-17
 ### Changed
 - `getRecommendedContentItems` now takes `options` object instead of `ContentType`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/cjam/react-native-spotify-remote/issues"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React Native wrapper around the Spotify Remote SDK",
   "author": {
     "name": "Colter McQuay"
@@ -31,8 +31,11 @@
     "watch": "yarn build --watch",
     "docs": "typedoc --options typedoc.json --excludeExternals",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublishOnly": "yarn submodules && yarn rebuild",
-    "submodules": "git submodule update --init --recursive",
+    "prepublishOnly": "yarn rebuild",
+    "prepack": "yarn submodules && yarn cleanup:ios",
+    "postpack": "yarn submodules",
+    "cleanup:ios": "pushd ios/external/SpotifySDK/SpotifyiOS.framework; rm SpotifyiOS Headers; mv Versions/Current/* .; popd",
+    "submodules": "rm -rf ios/external/* && git submodule update --init --recursive",
     "example": "concurrently -n \"server,packager\" -c \"yellow,cyan\" \"cd example-server && yarn start\" \"cd example && yarn start\""
   },
   "peerDependencies": {


### PR DESCRIPTION
Added some prepack scripts that unwrap the symlinks within the SpotifyiOS SDK so that the published version doesn't have headers / framework in strange location.