### PR TITLE
Refeshable tokens for android

### DIFF
--- a/android/src/main/java/com/reactlibrary/Convert.java
+++ b/android/src/main/java/com/reactlibrary/Convert.java
@@ -26,7 +26,16 @@ public class Convert {
             WritableMap map = Arguments.createMap();
             Calendar expirationDate = Calendar.getInstance();
             expirationDate.add(Calendar.SECOND,response.getExpiresIn());
-            map.putString("accessToken", response.getAccessToken());
+
+            switch (response.getType()) {
+                case TOKEN:
+                    map.putString("accessToken", response.getAccessToken());
+                    break;
+            
+                case CODE:
+                    map.putString("code", response.getCode());
+                    break;
+            }
             map.putString("expirationDate", expirationDate.toString());
             map.putBoolean("expired",Calendar.getInstance().after(expirationDate));
             return map;

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAuthModule.java
@@ -45,6 +45,7 @@ public class RNSpotifyRemoteAuthModule extends ReactContextBaseJavaModule implem
     public void authorize(ReadableMap config, Promise promise) {
         mConfig = config;
         String clientId = mConfig.getString("clientID");
+        String responseType = mConfig.getString("responseType");
         String redirectUri = mConfig.getString("redirectURL");
         Boolean showDialog = mConfig.getBoolean("showDialog");
         String[] scopes = convertScopes(mConfig);
@@ -54,11 +55,25 @@ public class RNSpotifyRemoteAuthModule extends ReactContextBaseJavaModule implem
                 .showAuthView(showDialog);
 
         authPromise = promise;
-        AuthorizationRequest.Builder builder = new AuthorizationRequest.Builder(
-                clientId,
-                AuthorizationResponse.Type.TOKEN,
-                redirectUri
-        );
+
+        AuthorizationRequest.Builder builder
+        switch(responseType){
+            case TOKEN:
+            builder = new AuthorizationRequest.Builder(
+                    clientId,
+                    AuthorizationResponse.Type.TOKEN,
+                    redirectUri
+            );
+            break;
+
+            case CODE:
+            builder = new AuthorizationRequest.Builder(
+                    clientId,
+                    AuthorizationResponse.Type.CODE,
+                    redirectUri
+            );
+            break;
+        }
         builder.setScopes(scopes);
         AuthorizationRequest request = builder.build();
         AuthorizationClient.openLoginActivity(getCurrentActivity(), REQUEST_CODE, request);
@@ -78,6 +93,14 @@ public class RNSpotifyRemoteAuthModule extends ReactContextBaseJavaModule implem
                 case TOKEN:
                     if (authPromise != null) {
                         String token = response.getAccessToken();
+                        mAuthResponse = response;
+                        authPromise.resolve(Convert.toMap(response, 'TOKEN'));
+                    }
+                    break;
+
+                    ase CODE:
+                    if (authPromise != null) {
+                        String token = response.getCode();
                         mAuthResponse = response;
                         authPromise.resolve(Convert.toMap(response));
                     }

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAuthModule.java
@@ -56,7 +56,7 @@ public class RNSpotifyRemoteAuthModule extends ReactContextBaseJavaModule implem
 
         authPromise = promise;
 
-        AuthorizationRequest.Builder builder
+        AuthorizationRequest.Builder builder;
         switch(responseType){
             case TOKEN:
             builder = new AuthorizationRequest.Builder(

--- a/src/ApiConfig.ts
+++ b/src/ApiConfig.ts
@@ -1,71 +1,79 @@
 import ApiScope from './ApiScope';
 
 export default interface SpotifyApiConfig {
+  /**
+   * Client Id of application registered with Spotify Api
+   * see https://developer.spotify.com/dashboard/applications
+   *
+   * @type {string}
+   * @memberof SpotifyApiConfig
+   */
+  clientID: string;
 
-    /**
-     * Client Id of application registered with Spotify Api
-     * see https://developer.spotify.com/dashboard/applications
-     *
-     * @type {string}
-     * @memberof SpotifyApiConfig
-     */
-    clientID:string;
+  /**
+   * The redirect url back to your application (i.e. myapp://spotify-login-callback )
+   *
+   * @type {string}
+   * @memberof SpotifyApiConfig
+   */
+  redirectURL: string;
 
-    /**
-     * The redirect url back to your application (i.e. myapp://spotify-login-callback )
-     *
-     * @type {string}
-     * @memberof SpotifyApiConfig
-     */
-    redirectURL:string;
+  /**
+   * Endpoint on your server to do token swap
+   *
+   * @type {string}
+   * @memberof SpotifyApiConfig
+   */
+  tokenSwapURL?: string;
 
-    /**
-     * Endpoint on your server to do token swap
-     *
-     * @type {string}
-     * @memberof SpotifyApiConfig
-     */
-    tokenSwapURL?:string;
+  /**
+   * Endpoint on your server to refesh token
+   *
+   * @type {string}
+   * @memberof SpotifyApiConfig
+   */
+  tokenRefreshURL?: string;
 
-    /**
-     * Endpoint on your server to refesh token
-     *
-     * @type {string}
-     * @memberof SpotifyApiConfig
-     */
-    tokenRefreshURL?:string;
+  /**
+   * URI of Spotify item to play upon authorization. `""` will
+   * attempt to resume playback from where it was.
+   *
+   * **Note:**
+   * *If Spotify is already open and playing, this parameter will not*
+   * *have any effect*
+   * @type {string}
+   * @memberof SpotifyApiConfig
+   */
+  playURI?: string;
 
-    /**
-     * URI of Spotify item to play upon authorization. `""` will 
-     * attempt to resume playback from where it was.
-     * 
-     * **Note:**
-     * *If Spotify is already open and playing, this parameter will not*
-     * *have any effect*
-     * @type {string}
-     * @memberof SpotifyApiConfig
-     */
-    playURI?:string;
+  /**
+   * Requested API Scopes, need to have AppRemoteControlScope
+   * to control playback of app
+   * @type {ApiScope}
+   * @memberof SpotifyApiConfig
+   */
+  scopes?: ApiScope[];
 
-    /**
-     * Requested API Scopes, need to have AppRemoteControlScope 
-     * to control playback of app
-     * @type {ApiScope}
-     * @memberof SpotifyApiConfig
-     */
-    scopes?:ApiScope[];
+  /**
+   * Whether or not the auth dialog should be shown.
+   * Useful for debugging auth flows.
+   *
+   * @type {boolean}
+   * @memberof SpotifyApiConfig
+   */
+  showDialog?: boolean;
 
-    /**
-     * Whether or not the auth dialog should be shown.
-     * Useful for debugging auth flows.
-     *
-     * @type {boolean}
-     * @memberof SpotifyApiConfig
-     */
-    showDialog?:boolean;
+  /**
+   * Choose the response type CODE or TOKEN.
+   * Useful to determine if you need a on time login or a longterm login.
+   *
+   * @type {'TOKEN' | 'CODE'}
+   * @memberof SpotifyApiConfig
+   */
+  responseType?: 'TOKEN' | 'CODE';
 }
 
-export const API_CONFIG_DEFAULTS :Partial<SpotifyApiConfig> = {
-    showDialog:false,
-    scopes:[]
-}
+export const API_CONFIG_DEFAULTS: Partial<SpotifyApiConfig> = {
+  showDialog: false,
+  scopes: [],
+};


### PR DESCRIPTION
I'm working with this library in an android app and I found that there is no option for android to get a refreshable tokens for android as the response type is fixed to TOKEN and no option for Code (Authorization code) option. I made these changes to be able to choose the response type.

there is a problem with implementation which is the getSession method now wont work as it will return a useless code as it a one use code. the solution for this problem to implement the logic for sending the requests for swap and refresh tokens in the java code. I couldn't implement it as I'm not an expert in writing java code. but I made a workaround to get it to work on my project.

### workaround
I got the Authorization code by sitting the contentType to code. and then the code below to send the requests and refresh the token and store the token and the refresh tokens in a AsyncStorage and a global Api Context to access them.

I know that this pull request is unmergable right no but I wanted to show the Idea to be the start to implementing the full solution for long term authentication for android using this package.