### PR TITLE
Adding error messages for failed connections (Android)

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
@@ -59,11 +59,11 @@ public class RNSpotifyRemoteAppModule extends ReactContextBaseJavaModule impleme
             public void onFailure(Throwable throwable) {
                 while (!mConnectPromises.empty()) {
                     Promise promise = mConnectPromises.pop();
-                    if (error instanceof NotLoggedInException) {
+                    if (throwable instanceof NotLoggedInException) {
                         promise.reject(new Error("Spotify connection failed: user is not logged in."));
-                    } else if (error instanceof UserNotAuthorizedException) {
+                    } else if (throwable instanceof UserNotAuthorizedException) {
                         promise.reject(new Error("Spotify connection failed: user is not authorized."));
-                    } else if (error instanceof CouldNotFindSpotifyApp) {
+                    } else if (throwable instanceof CouldNotFindSpotifyApp) {
                         promise.reject(new Error("Spotify connection failed: could not find the Spotify app, it may need to be installed."));
                     }
                 }

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
@@ -17,6 +17,9 @@ import com.lufinkey.react.eventemitter.RNEventEmitter;
 import com.spotify.android.appremote.api.ConnectionParams;
 import com.spotify.android.appremote.api.Connector;
 import com.spotify.android.appremote.api.SpotifyAppRemote;
+import com.spotify.protocol.error.CouldNotFindSpotifyApp;
+import com.spotify.protocol.error.NotLoggedInException;
+import com.spotify.protocol.error.UserNotAuthorizedException;
 
 import com.lufinkey.react.eventemitter.RNEventConformer;
 
@@ -56,7 +59,13 @@ public class RNSpotifyRemoteAppModule extends ReactContextBaseJavaModule impleme
             public void onFailure(Throwable throwable) {
                 while (!mConnectPromises.empty()) {
                     Promise promise = mConnectPromises.pop();
-                    promise.reject(throwable);
+                    if (error instanceof NotLoggedInException) {
+                        promise.reject(new Error("Spotify connection failed: user is not logged in."));
+                    } else if (error instanceof UserNotAuthorizedException) {
+                        promise.reject(new Error("Spotify connection failed: user is not authorized."));
+                    } else if (error instanceof CouldNotFindSpotifyApp) {
+                        promise.reject(new Error("Spotify connection failed: could not find the Spotify app, it may need to be installed."));
+                    }
                 }
                 sendEvent("remoteDisconnected", null);
             }

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
@@ -65,6 +65,8 @@ public class RNSpotifyRemoteAppModule extends ReactContextBaseJavaModule impleme
                         promise.reject(new Error("Spotify connection failed: user is not authorized."));
                     } else if (throwable instanceof CouldNotFindSpotifyApp) {
                         promise.reject(new Error("Spotify connection failed: could not find the Spotify app, it may need to be installed."));
+                    } else {
+                        promise.reject(throwable);   
                     }
                 }
                 sendEvent("remoteDisconnected", null);

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
@@ -17,9 +17,9 @@ import com.lufinkey.react.eventemitter.RNEventEmitter;
 import com.spotify.android.appremote.api.ConnectionParams;
 import com.spotify.android.appremote.api.Connector;
 import com.spotify.android.appremote.api.SpotifyAppRemote;
-import com.spotify.protocol.error.CouldNotFindSpotifyApp;
-import com.spotify.protocol.error.NotLoggedInException;
-import com.spotify.protocol.error.UserNotAuthorizedException;
+import com.spotify.android.appremote.api.error.CouldNotFindSpotifyApp;
+import com.spotify.android.appremote.api.error.NotLoggedInException;
+import com.spotify.android.appremote.api.error.UserNotAuthorizedException;
 
 import com.lufinkey.react.eventemitter.RNEventConformer;
 


### PR DESCRIPTION
As mentioned in #81, if the SpotifyRemote.connect() method fails on Android due to an unauthorized user or the Spotify app not being installed, there is no error message returned. This PR should at least provide some indication of the issue. Code based on [Spotify's own docs](https://developer.spotify.com/documentation/android/guides/application-lifecycle/).

I'm not sure if this is an issue on iOS as I don't have access to a device.

While the error messages are at least descriptive now, I think it would be better to use error codes so that they can be handled programatically. [See here](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.java) for more info on rejecting promises with codes. I would propose something like:

```java
promise.reject("SpotifyAppRemote/NotLoggedIn", "Spotify connection failed: user is not logged in.");
```