### PR TITLE
Allow incomplete ListItem when calling playItemWithIndex (Android)

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
@@ -201,8 +201,7 @@ public class RNSpotifyRemoteAppModule extends ReactContextBaseJavaModule impleme
     public void playItemWithIndex(ReadableMap map, int index, Promise promise) {
         executeAppRemoteCall(
                 api -> {
-                    ListItem item = Convert.toItem(map);
-                    return api.getPlayerApi().skipToIndex(item.uri, index);
+                    return api.getPlayerApi().skipToIndex(map.getString("uri"), index);
                 },
                 empty -> promise.resolve(null),
                 err -> promise.reject(err)


### PR DESCRIPTION
I was trying to use the playItemWithIndex() method and since the getContentItemForUri() method isn't available on Android, I have to create an entire dummy ListItem object with the URI in. Under the hood only the URI is needed, so I thought it made sense to modify the playItemWithIndex method to accept a non-complete ListItem object on Android. So long as the URI is specified, it still works. 

For example:

```javascript
// Intead of this
const contentItem = {
    id: '',
    uri: 'spotify:playlist:37i9dQZF1DWSrVdvTl1tVY',
    title: '',
    subtitle: '',
    playable: true,
    container: true,
}
remote.playItemWithIndex(contentItem, 3);


// You can just do this
remote.playItemWithIndex({uri:'spotify:playlist:37i9dQZF1DWSrVdvTl1tVY'}, 3);
```

It's not the most elegant solution in the world but it could save some hassle. Thoughts?

It's a very simple change but I did test it just to be sure and it works as intended. Interesting side-note, if shuffling is enabled then the index doesn't actually select the track you'd expect, it's random.