### PR TITLE
Fix iOS returning access token instead of session object when re-authing

### DIFF
--- a/ios/RNSpotifyRemoteAuth.m
+++ b/ios/RNSpotifyRemoteAuth.m
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(authorize:(NSDictionary*)options resolve:(RCTPromiseResolveBlo
     
     if(_initialized && [_sessionManager session]!= nil && [_sessionManager session].isExpired == NO)
     {
-        [completion resolve:[_sessionManager session].accessToken];
+        [completion resolve:[RNSpotifyRemoteConvert SPTSession:_sessionManager.session]];
         return;
     }
     _isInitializing = YES;

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "source": "src/index",
-  "react-native": "src/index",
+  "source": "dist/index",
+  "react-native": "dist/index",
   "scripts": {
     "rebuild": "yarn build && yarn docs",
     "clean": "rm -rf ./dist",


### PR DESCRIPTION
When making a call to the `authorize` method I noticed a bug in the iOS implementation. The first time it is called, a session object is correctly returned. If the method is called a second time, when a session has already been initialized, it incorrectly returns just the accessToken string as opposed to the whole session object.

Tested and working :)