### PR TITLE
Implement playerContextChange events

### DIFF
--- a/android/src/main/java/com/reactlibrary/Convert.java
+++ b/android/src/main/java/com/reactlibrary/Convert.java
@@ -14,6 +14,7 @@ import com.spotify.protocol.types.ListItems;
 import com.spotify.protocol.types.PlayerOptions;
 import com.spotify.protocol.types.PlayerRestrictions;
 import com.spotify.protocol.types.PlayerState;
+import com.spotify.protocol.types.PlayerContext;
 import com.spotify.protocol.types.Track;
 import com.spotify.sdk.android.auth.AuthorizationResponse;
 
@@ -138,6 +139,16 @@ public class Convert {
         map.putMap("playbackOptions", Convert.toMap(playerState.playbackOptions));
         map.putMap("playbackRestrictions", Convert.toMap(playerState.playbackRestrictions));
         map.putMap("track", Convert.toMap(playerState.track));
+
+        return map;
+    }
+
+
+    public static ReadableMap toMap(PlayerContext playerContext) {
+        WritableMap map = Arguments.createMap();
+
+        map.putString("title", playerContext.title);
+        map.putString("uri", playerContext.uri);
 
         return map;
     }

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAppModule.java
@@ -40,7 +40,6 @@ public class RNSpotifyRemoteAppModule extends ReactContextBaseJavaModule impleme
     private SpotifyAppRemote mSpotifyAppRemote;
     private Connector.ConnectionListener mSpotifyRemoteConnectionListener;
     private Stack<Promise> mConnectPromises = new Stack<Promise>();
-    private ReadableMap mPlayerContext;
 
     public RNSpotifyRemoteAppModule(ReactApplicationContext reactContext) {
         super(reactContext);

--- a/example/AppContext.tsx
+++ b/example/AppContext.tsx
@@ -6,6 +6,7 @@ import {
     ApiScope,
     SpotifyRemoteApi,
     PlayerState,
+    PlayerContext,
     RepeatMode,
     ContentItem,
     SpotifyAuth
@@ -64,13 +65,15 @@ class AppContextProvider extends React.Component<{}, AppContextState> {
         this.onConnected = this.onConnected.bind(this);
         this.onDisconnected = this.onDisconnected.bind(this);
         this.onPlayerStateChanged = this.onPlayerStateChanged.bind(this);
+        this.onPlayerContextChanged = this.onPlayerContextChanged.bind(this);
         this.endSession = this.endSession.bind(this);
     }
 
     componentDidMount() {
         remote.on("remoteConnected", this.onConnected)
             .on("remoteDisconnected", this.onDisconnected)
-            .on("playerStateChanged", this.onPlayerStateChanged);
+            .on("playerStateChanged", this.onPlayerStateChanged)
+            .on("playerContextChanged", this.onPlayerContextChanged);
 
         auth.getSession().then((session) => {
             if (session != undefined && session.accessToken != undefined) {
@@ -115,7 +118,14 @@ class AppContextProvider extends React.Component<{}, AppContextState> {
         this.setState((state) => ({
             ...state,
             playerState
-        }))
+        }));
+    };
+
+    private onPlayerContextChanged(playerContext: PlayerContext) {
+        this.setState((state) => ({
+            ...state,
+            playerContext
+        }));
     };
 
     private endSession() {

--- a/ios/RNSpotifyRemoteAppRemote.m
+++ b/ios/RNSpotifyRemoteAppRemote.m
@@ -14,6 +14,7 @@
 #define SPOTIFY_API_URL(endpoint) [NSURL URLWithString:NSString_concat(SPOTIFY_API_BASE_URL, endpoint)]
 
 static NSString * const EventNamePlayerStateChanged = @"playerStateChanged";
+static NSString * const EventNamePlayerContextChanged = @"playerContextChanged";
 static NSString * const EventNameRemoteDisconnected = @"remoteDisconnected";
 static NSString * const EventNameRemoteConnected = @"remoteConnected";
 
@@ -135,10 +136,9 @@ static RNSpotifyRemoteAppRemote *sharedInstance = nil;
 #pragma mark - SPTAppRemotePlayerStateDelegate implementation
 
 - (void)playerStateDidChange:(nonnull id<SPTAppRemotePlayerState>)playerState {
-    [self sendEvent:EventNamePlayerStateChanged args:@[
-        [RNSpotifyRemoteConvert SPTAppRemotePlayerState:playerState]
-        ]
-    ];
+    NSDictionary *state = [RNSpotifyRemoteConvert SPTAppRemotePlayerState:playerState];
+    [self sendEvent:EventNamePlayerStateChanged args:@[state[@"state"]]];
+    [self sendEvent:EventNamePlayerContextChanged args:@[state[@"context"]]];
 }
 
 #pragma mark - SPTAppRemoteDelegate implementation
@@ -190,9 +190,9 @@ static RNSpotifyRemoteAppRemote *sharedInstance = nil;
                 [[RNSpotifyRemoteError errorWithNSError:error] reject:reject];
             }else if( [result conformsToProtocol:@protocol(SPTAppRemotePlayerState)]){
                 // Send a playerStateChanged event since we went and retrieved it anyways
-                [self sendEvent:EventNamePlayerStateChanged args:@[
-                    [RNSpotifyRemoteConvert SPTAppRemotePlayerState:result]
-                ]];
+                NSDictionary *state = [RNSpotifyRemoteConvert SPTAppRemotePlayerState:result];
+                [self sendEvent:EventNamePlayerStateChanged args:@[state[@"state"]]];
+                [self sendEvent:EventNamePlayerContextChanged args:@[state[@"context"]]];
                 resolve(result);
             }else{
                 [[RNSpotifyRemoteError errorWithCodeObj:RNSpotifyRemoteErrorCode.UnknownResponse] reject:reject];
@@ -340,7 +340,7 @@ RCT_EXPORT_METHOD(setRepeatMode: (NSInteger)repeatMode resolve:(RCTPromiseResolv
 
 RCT_EXPORT_METHOD(getPlayerState:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject){
     [self getPlayerStateInternal:^(id<SPTAppRemotePlayerState> state) {
-        resolve([RNSpotifyRemoteConvert SPTAppRemotePlayerState:state]);
+        resolve([RNSpotifyRemoteConvert SPTAppRemotePlayerState:state][@"state"]);
     } reject:reject];
 }
 

--- a/ios/RNSpotifyRemoteConvert.m
+++ b/ios/RNSpotifyRemoteConvert.m
@@ -75,12 +75,18 @@ static NSDateFormatter* _ISO_DATE_FORMATTER;
         return [NSNull null];
     }
     return @{
-        @"track": [RNSpotifyRemoteConvert SPTAppRemoteTrack:state.track],
-        @"playbackPosition": [NSNumber numberWithInteger:state.playbackPosition],
-        @"playbackSpeed": [NSNumber numberWithFloat:state.playbackSpeed],
-        @"isPaused": [NSNumber numberWithBool:state.isPaused],
-        @"playbackRestrictions": [RNSpotifyRemoteConvert SPTAppRemotePlaybackRestrictions:state.playbackRestrictions],
-        @"playbackOptions": [RNSpotifyRemoteConvert SPTAppRemotePlaybackOptions:state.playbackOptions]
+        @"state": @{
+            @"track": [RNSpotifyRemoteConvert SPTAppRemoteTrack:state.track],
+            @"playbackPosition": [NSNumber numberWithInteger:state.playbackPosition],
+            @"playbackSpeed": [NSNumber numberWithFloat:state.playbackSpeed],
+            @"isPaused": [NSNumber numberWithBool:state.isPaused],
+            @"playbackRestrictions": [RNSpotifyRemoteConvert SPTAppRemotePlaybackRestrictions:state.playbackRestrictions],
+            @"playbackOptions": [RNSpotifyRemoteConvert SPTAppRemotePlaybackOptions:state.playbackOptions]
+        },
+        @"context": @{
+            @"title": state.contextTitle,
+            @"uri": state.contextURI
+        }
     };
 }
 

--- a/src/PlayerContext.ts
+++ b/src/PlayerContext.ts
@@ -1,0 +1,4 @@
+export default interface PlayerContext {
+    title: String;
+    uri: String;
+}

--- a/src/PlayerContext.ts
+++ b/src/PlayerContext.ts
@@ -1,4 +1,4 @@
 export default interface PlayerContext {
-    title: String;
-    uri: String;
+    title: string;
+    uri: string;
 }

--- a/src/SpotifyRemote.ts
+++ b/src/SpotifyRemote.ts
@@ -3,6 +3,7 @@ import RNEvents from 'react-native-events';
 import TypedEventEmitter from './TypedEventEmitter';
 import RepeatMode from './RepeatMode';
 import PlayerState from './PlayerState';
+import PlayerContext from './PlayerContext';
 import ContentItem from './ContentItem';
 import CrossfadeState from './CrossfadeState';
 import RecommendedContentOptions from './RecommendedContentOptions';
@@ -23,6 +24,14 @@ export interface SpotifyRemoteEvents {
      * @memberof SpotifyRemoteEvents
      */
     "playerStateChanged": PlayerState;
+
+    /**
+     * Fires when the context of the Spotify Player changes
+     * 
+     * @type {PlayerContext}
+     * @memberof SpotifyRemoteEvents
+     */
+    "playerContextChanged": PlayerContext;
 
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { default as ApiConfig } from './ApiConfig'
 export { default as ApiScope } from './ApiScope';
 export { default as RepeatMode } from './RepeatMode'
 export { default as PlayerState } from './PlayerState';
+export { default as PlayerContext } from './PlayerContext';
 export { default as Track } from './Track';
 export { default as Artist } from './Artist';
 export { default as Album } from './Album';


### PR DESCRIPTION
On Android, we can subscribe to player context changes (i.e. the album or playlist we are playing the track inside of) separately from player state changes. On iOS, the context is included with the player state. I assume it is due to this strange inconsistency between the SDKs that player context had been previously ignored in this library.

If you think this inconsistency is a bit silly, like I do, then please head over to [my post](https://community.spotify.com/t5/Spotify-for-Developers/Why-are-the-iOS-and-Android-SDK-implementations-of-player/td-p/5175512) on the Spotify Developer forums and show your support!

My proposed solution is to subscribe to player context updates on Android at the same time as player state updates, firing a new `playerContextChange` event for each update. Then, on iOS, we simply fire both events with every player state update. Unfortunately this means on iOS we get context updates a bit more frequently than necessary, since they're fired with every single player state change, but at least we get them.

I've never written any Objective-C code before doing this PR so I apologise if any of my code is messy or goes against convention. I have tested this and it seems to be working.

Perhaps I should also add something to the example app to display the current context?

Note the docs need updating, too. If I try to rebuild them they end up with all the wrong URLs since it's on a different fork.