### PR TITLE
Avoid crash if session object is not ok

### DIFF
--- a/ios/RNSpotifyRemoteConvert.m
+++ b/ios/RNSpotifyRemoteConvert.m
@@ -205,7 +205,7 @@ static NSDateFormatter* _ISO_DATE_FORMATTER;
 }
 
 +(id)SPTSession:(SPTSession *)session{
-    if(session == nil){
+    if(session == nil || session.accessToken == nil || session.refreshToken == nil){
         return [NSNull null];
     }
     


### PR DESCRIPTION
It is not clear yet what is the case that generate this, but I had some crashes because the `accessToken` was nil.