### PR TITLE
fix: missing SpotifyiOS.h in example

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prepublishOnly": "yarn rebuild",
     "prepack": "yarn submodules && yarn cleanup:ios",
     "postpack": "yarn submodules",
+    "postinstall": "yarn submodules",
     "cleanup:ios": "pushd ios/external/SpotifySDK/SpotifyiOS.framework; rm SpotifyiOS Headers; mv Versions/Current/* .; popd",
     "submodules": "rm -rf ios/external/* && rm -rf android/external/* && git submodule update --init --recursive",
     "example": "concurrently -n \"server,packager\" -c \"yellow,cyan\" \"cd example-server && yarn start\" \"cd example && yarn start\"",


### PR DESCRIPTION
This has been reported a couple of times before:
https://github.com/cjam/react-native-spotify-remote/issues/78
https://github.com/cjam/react-native-spotify-remote/issues/63