### PR TITLE
Remove NPM hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "yarn rebuild",
     "prepack": "yarn submodules && yarn cleanup:ios",
-    "postpack": "yarn submodules",
-    "postinstall": "yarn submodules",
     "cleanup:ios": "pushd ios/external/SpotifySDK/SpotifyiOS.framework; rm SpotifyiOS Headers; mv Versions/Current/* .; popd",
     "submodules": "rm -rf ios/external/* && rm -rf android/external/* && git submodule update --init --recursive",
     "example": "concurrently -n \"server,packager\" -c \"yellow,cyan\" \"cd example-server && yarn start\" \"cd example && yarn start\"",


### PR DESCRIPTION
The intention of this PR is in https://github.com/cjam/react-native-spotify-remote/pull/162#issuecomment-944840604

- `postinstall` hook requires user to install `yarn` and use a Linux-base machine (because of `rm -rf` command)
- `postpack` does not really do anything because it is run *after* the tarball is generated