### PR TITLE
Remove double-quoted import

### DIFF
--- a/ios/RNSpotifyRemoteAuth.h
+++ b/ios/RNSpotifyRemoteAuth.h
@@ -1,10 +1,6 @@
 #import <UIKit/UIKit.h>
 #import <SpotifyiOS/SpotifyiOS.h>
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 #import "RNSpotifyRemotePromise.h"
 
 @interface RNSpotifyRemoteAuth : NSObject<RCTBridgeModule>


### PR DESCRIPTION
The double-quoted import is for react-native < 0.40, which is outdated. Some libs had compatibility issues with expo because of this, so I think this change will help to keep the code fresh.