### PR TITLE
Add a null check when mapping tracks

### DIFF
--- a/android/src/main/java/com/reactlibrary/Convert.java
+++ b/android/src/main/java/com/reactlibrary/Convert.java
@@ -105,6 +105,9 @@ public class Convert {
     }
 
     public static ReadableMap toMap(Track track) {
+        if (track == null) {
+            return null;
+        }
         WritableMap map = Arguments.createMap();
 
         map.putDouble("duration", (double) track.duration);


### PR DESCRIPTION
When Spotify is not playing a track (ex after logging in) track is null, causing an "Attempt to read...on a null object reference" exception

Related to #191

Similar to the [iOS check](https://github.com/cjam/react-native-spotify-remote/blob/master/ios/RNSpotifyRemoteConvert.m#L121)