### PR TITLE
Update gradle to direct include aar files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Update gradle to direct include aar files to fix [#194](https://github.com/cjam/react-native-spotify-remote/issues/194) 
+
 ## [0.3.11-6] - 2022-06-04
 
 ### Fix

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,14 +59,15 @@ repositories {
     google()
     mavenCentral()
     jcenter()
+    flatDir {
+        dirs 'external/SpotifySDK/app-remote-lib'
+        dirs 'external/SpotifySDK/auth-lib'
+    }
 }
 
-
-
 dependencies {
-    def externalLibs = fileTree(dir: "$projectDir/external", include: '**/*.aar').collect()
-    println("Adding external libraries ${externalLibs}")
-    implementation files(externalLibs)
+    implementation (name: "spotify-auth-release-1.2.3", ext: "aar")
+    implementation (name: "spotify-app-remote-release-0.7.2", ext: "aar")
     implementation "com.google.code.gson:gson:2.8.5"  // needed by spotify-app-remote
     implementation project(path: ':react-native-events')  // From node_module
     //noinspection GradleDynamicVersion


### PR DESCRIPTION
This PR should solve https://github.com/cjam/react-native-spotify-remote/issues/194 