### PR TITLE
feat: upgrade Android Auth library to 2.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ repositories {
 }
 
 dependencies {
-    implementation (files("external/SpotifySDK/auth-lib/spotify-auth-release-1.2.3.aar"))
+    implementation (files("external/SpotifySDK/auth-lib/spotify-auth-release-2.0.1.aar"))
     implementation (files("external/SpotifySDK/app-remote-lib/spotify-app-remote-release-0.7.2.aar"))
     implementation "com.google.code.gson:gson:2.8.5"  // needed by spotify-app-remote
     //noinspection GradleDynamicVersion

--- a/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpotifyRemoteAuthModule.java
@@ -120,8 +120,6 @@ public class RNSpotifyRemoteAuthModule extends ReactContextBaseJavaModule implem
         mConnectionParamsBuilder = null;
         mConfig = null;
 
-        AuthorizationClient.clearCookies(this.getReactApplicationContext());
-
         RNSpotifyRemoteAppModule remoteModule = reactContext.getNativeModule(RNSpotifyRemoteAppModule.class);
         if (remoteModule != null) {
             remoteModule.disconnect(promise);


### PR DESCRIPTION
Fixes #209 .

Changes introduced in this pull request:

- Update SpotifySDK submodule to latest commit
- Update build.gradle to use the new auth-lib.aar
- Remove clearCookies method call as this no longer exists in new SDK

## Tasks 
- [ ] Add yourself as contributor via `yarn contribute`
- [ ] Update `Unreleased` section of  `CHANGELOG.md` with changes ([Convention](https://keepachangelog.com/en/1.0.0/))


@cjam

Please note I'm having problems testing this change so there's a high chance it doesn't work. However, everything in Android Studio is saying it's okay so I'm hopeful it should work. I just couldn't get a package to build I could import into my project to make sure. 